### PR TITLE
Sort out the architecture

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,4 +47,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/dep-cache
       - name: Check Types
-        run: yarn check
+        run: yarn ts-check

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build": "yarn tauri build",
     "build:web": "vite build",
     "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "ts-check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "ts-check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --plugin-search-dir . --check . && eslint .",
     "format": "prettier --plugin-search-dir . --write .",
     "prepare": "svelte-kit sync"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,7 +10,7 @@ use tokio::io::AsyncReadExt;
 use tokio::process::{Child, Command as OsCommand};
 use uuid::Uuid;
 
-#[derive(Clone, Copy, PartialOrd, Hash, PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, PartialOrd, Hash, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[repr(transparent)]
 pub struct CommandId(Uuid);
 
@@ -32,12 +32,6 @@ pub enum CommandData {
     Status(CommandStatus),
     Stdout(String),
     Stderr(String),
-}
-
-lazy_static! {
-// TODO: will this be a bottleneck?
-static ref RUNNING_COMMANDS: Mutex<HashMap<CommandId, Option<CommandStatus>>> =
-    Mutex::new(HashMap::new());
 }
 
 pub struct Command {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,11 +10,11 @@ use tokio::io::AsyncReadExt;
 use tokio::process::{Child, Command as OsCommand};
 use uuid::Uuid;
 
-#[derive(Clone, Copy, PartialOrd, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialOrd, Hash, PartialEq, Serialize, Deserialize, Debug)]
 #[repr(transparent)]
 pub struct CommandId(Uuid);
 
-#[derive(Serialize, Clone, Copy)]
+#[derive(Serialize, Debug, Clone, Copy)]
 pub struct CommandStatus {
     pub success: bool,
     pub exit_code: Option<i32>,
@@ -52,6 +52,17 @@ pub struct Command {
     channel: tokio::sync::mpsc::Receiver<CommandData>,
     exit_status: Option<CommandStatus>,
     kill: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl std::fmt::Debug for Command {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Command")
+            .field("id", &self.id)
+            .field("command", &self.command)
+            .field("exit_status", &self.exit_status)
+            .field("done", &self.done.load(Ordering::SeqCst))
+            .finish()
+    }
 }
 
 impl Command {

--- a/src-tauri/src/sheet.rs
+++ b/src-tauri/src/sheet.rs
@@ -1,16 +1,152 @@
 use crate::commands::Command;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use uuid::Uuid;
 
-#[derive(Clone, Copy, PartialOrd, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialOrd, Hash, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct CellId(Uuid);
+pub struct CellId(u32);
+
+struct CellIdVisitor;
+
+impl<'de> serde::de::Visitor<'de> for CellIdVisitor {
+    type Value = CellId;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("an ID in hex")
+    }
+
+    fn visit_borrowed_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        return self.visit_str(v);
+    }
+    fn visit_string<E: serde::de::Error>(self, v: String) -> Result<Self::Value, E> {
+        return self.visit_str(&v);
+    }
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        match u32::from_str_radix(v, 16) {
+            Ok(v) => return Ok(CellId(v)),
+            Err(e) => return Err(E::invalid_value(serde::de::Unexpected::Str(v), &self)),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CellId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_string(CellIdVisitor)
+    }
+}
+
+impl Serialize for CellId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("{:08x}", self.0))
+    }
+}
 
 pub struct Sheet {
-    relations: BTreeMap<(CellId, CellId), ()>,
-    layout: Vec<CellId>,
-    running_commands: HashMap<CellId, Arc<Mutex<Command>>>,
+    id_seed: u32,
+
+    // Always having at least 1 column makes things a little easier to think about,
+    // since cell_layout uses row-major order.
+    columns: NonZeroU32,
+    cell_layout: Vec<CellId>,
+
+    cells: HashMap<CellId, Cell>,
+}
+
+pub struct Cell {
+    pub id: CellId,
+    pub invocation: Option<Arc<Mutex<Command>>>,
+}
+
+impl Sheet {
+    pub fn new() -> Self {
+        return Self {
+            id_seed: 0,
+            cell_layout: Vec::new(),
+            columns: NonZeroU32::MIN,
+            cells: HashMap::new(),
+        };
+    }
+
+    pub fn cell_at(&self, row: u32, col: u32) -> Option<CellId> {
+        if col >= self.columns.get() {
+            return None;
+        }
+
+        let index = row * self.columns.get() + col;
+        let cell_slot = self.cell_layout.get(index as usize)?;
+
+        return Some(*cell_slot);
+    }
+
+    pub fn rows(&self) -> u32 {
+        let rows = self.cell_layout.len() / self.columns.get() as usize;
+        return rows as u32;
+    }
+
+    pub fn columns(&self) -> u32 {
+        return self.columns.get();
+    }
+
+    pub fn get_cell(&self, id: CellId) -> Option<&Cell> {
+        return self.cells.get(&id);
+    }
+
+    /// Resizes the sheet, potentially deleting or adding cells.
+    pub fn resize(&mut self, rows: u32, columns: u32) {
+        let columns = NonZeroU32::new(columns).unwrap_or(NonZeroU32::MIN);
+        let new_size = columns.get() as usize * rows as usize;
+
+        let mut new_layout = Vec::with_capacity(new_size);
+
+        let mut index = 0;
+        let source_rows = self.rows();
+
+        for _row in 0..source_rows {
+            for _column in 0..self.columns.get() {
+                new_layout.push(self.cell_layout[index]);
+                index += 1;
+            }
+
+            // NOTE: we're taking advantage of the fact that something like
+            // 100..0 is a valid range but doesn't result in any loop iterations
+            for _new_col in self.columns.get()..columns.get() {
+                new_layout.push(self.create_cell());
+            }
+        }
+
+        // NOTE: we're taking advantage of the fact that something like
+        // 100..0 is a valid range but doesn't result in any loop iterations
+        for _row in source_rows..rows {
+            for _new_col in 0..columns.get() {
+                new_layout.push(self.create_cell());
+            }
+        }
+
+        self.columns = columns;
+        self.cell_layout = new_layout;
+    }
+
+    fn create_cell(&mut self) -> CellId {
+        let id = CellId(self.id_seed);
+        self.id_seed += 1;
+
+        self.cells.insert(
+            id,
+            Cell {
+                id,
+                invocation: None,
+            },
+        );
+
+        return id;
+    }
 }

--- a/src-tauri/src/util/id.rs
+++ b/src-tauri/src/util/id.rs
@@ -1,0 +1,70 @@
+use serde::{Deserialize, Serialize};
+
+const ID_MASK: u32 = 0b10100110_01101010_01001010_10101010;
+const ID_ADD: u32 = 2740160927;
+
+// These two numbers are multiplicative inverses mod 2^32
+const ID_MUL_TO: u32 = 0x01000193;
+const ID_MUL_FROM: u32 = 0x359c449b;
+
+// const ID_ROTATE_BITS: u32 = 16;
+// let s2 = s1.swap_bytes();
+// let s5 = s4.rotate_left(ID_ROTATE_BITS);
+
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct Id32(u32);
+
+impl Id32 {
+    pub fn from_seed(seed: u32) -> Self {
+        let s3 = seed.wrapping_add(ID_ADD);
+        let s2 = s3.wrapping_mul(ID_MUL_FROM);
+        let s1 = s2 ^ ID_MASK;
+
+        return Self(s1);
+    }
+
+    pub fn get_seed(self) -> u32 {
+        let s1 = self.0 ^ ID_MASK;
+        let s2 = s1.wrapping_mul(ID_MUL_TO);
+        let s3 = s2.wrapping_sub(ID_ADD);
+
+        return s3;
+    }
+}
+
+#[test]
+fn id_test() {
+    assert_eq!(ID_MUL_TO.wrapping_mul(ID_MUL_FROM), 1);
+
+    let tests = &[ID_MASK, ID_ADD, ID_MUL_TO, ID_MUL_FROM];
+
+    for id in 0..100 {
+        let value = Id32::from_seed(id);
+        let out_id = value.get_seed();
+
+        // println!("{} -> {}", id, value);
+
+        // println!("{:>10}", value);
+
+        assert_eq!(id, out_id);
+    }
+
+    for &id in tests {
+        let value = Id32::from_seed(id);
+        let out_id = value.get_seed();
+
+        // println!("{} -> {}", id, value);
+
+        assert_eq!(id, out_id);
+    }
+
+    for value in 0..100 {
+        let id = Id32(value).get_seed();
+        let out_value = Id32::from_seed(id);
+
+        // println!("{} -> {}", id, value);
+
+        assert_eq!(value, out_value.0);
+    }
+}

--- a/src-tauri/src/util/mod.rs
+++ b/src-tauri/src/util/mod.rs
@@ -1,0 +1,3 @@
+mod id;
+
+pub use id::*;

--- a/web/lib/handlers.ts
+++ b/web/lib/handlers.ts
@@ -1,5 +1,30 @@
+import { invoke } from "@tauri-apps/api/tauri";
+
 export const Handlers = {
   zsh: {
     command: "run_zsh",
   },
 } as const;
+
+export interface CommandStatus {
+  success: boolean;
+  exitCode: number | null;
+}
+
+export interface CommandData {
+  Stderr?: string;
+  Stdout?: string;
+}
+
+interface PollResult {
+  end: boolean;
+  status: CommandStatus | null;
+  data: CommandData[];
+}
+
+export async function pollCommand(props: {
+  id: string;
+  timeoutMs: number;
+}): Promise<PollResult> {
+  return invoke("poll_command", props);
+}

--- a/web/routes/file/EditCell.svelte
+++ b/web/routes/file/EditCell.svelte
@@ -24,8 +24,8 @@
   }
 
   interface CommandOutput {
-    stdout: string;
-    stderr: string;
+    cell: CellInfo;
+    commandId: Promise<string>;
   }
   function keyHandler(
     e: KeyboardEvent,
@@ -115,7 +115,8 @@
       });
       if (!pollOut) {
         timeoutMs *= 2;
-        timeoutMs = Math.min(500, timeoutMs);
+        timeoutMs = Math.min(400, timeoutMs);
+        continue;
       } else {
         timeoutMs = 50;
       }


### PR DESCRIPTION
- Layout should be in the frontend because it should be reactive to user input, and reactivity is easiest to do when its not smashing in and out of the frontend
- Command data + env stuff should probably be in native? It's really really easy to fuck up a command and make an infinite loop, the browser part really shouldn't store all that data all at once

So I guess... no layout in native? So `Sheet` will contain cell IDs but no layout? The command text probably also doesn't need to be in native.

I guess that means that native really only stores the output of large commands.



Final decision:
- punt for now, keep everything in web except for command running system
- Will probably eventually need some cell stuff to be in native but can ignore for now